### PR TITLE
Remove semicolons.

### DIFF
--- a/DaOS.py
+++ b/DaOS.py
@@ -159,4 +159,4 @@ time.sleep(3);
 print("DaOS successfully booted.");
 print("LET'S GOOOOO!!!!!!");
 time.sleep(5);
-print(dababy_convertible);
+print(daDesktop);


### PR DESCRIPTION
Python doesn't use semicolons, instead it uses a new line as a command unlike JS.
Since there wasn't an issues tab I had to state this here ._.\

https://towardsdatascience.com/stop-using-semicolons-in-python-fd3ce4ff1086